### PR TITLE
Correctly detect no cookies on a server request

### DIFF
--- a/lib/withData.js
+++ b/lib/withData.js
@@ -6,7 +6,7 @@ import Head from 'next/head'
 import initApollo from './initApollo'
 
 function getCookie(context = {}) {
-	return context.req && context.req.headers.cookie
+	return context.req && context.req.headers
 		? context.req.headers.cookie
 		: document.cookie
 }


### PR DESCRIPTION
First off, thanks for your great boilerplate!

While customizing it for my use case, I noticed that I'd get a `document is not defined` error if I visited my app from an incognito window, which lead me to find this bug. If your incoming server request has no cookies defined in the requests headers, this ternary statement will hit the false case and attempt to return `document.cookie` on the server side, throwing an error. This fixes it up.